### PR TITLE
feat: afterSuccess

### DIFF
--- a/apps/ng-integration/src/app/+state/entities/posts.state.ts
+++ b/apps/ng-integration/src/app/+state/entities/posts.state.ts
@@ -1,9 +1,23 @@
 import { Injectable } from '@angular/core';
+import { AfterSuccess } from '@lyxs/angular';
+import { OperationContext } from '@lyxs/angular/internal';
 import { PaginatedCrudCollection, PaginatedCrudCollectionState } from '@lyxs/angular/pagination';
+import { Observable } from 'rxjs';
+
+interface Post {
+    userId: number;
+    id: number;
+    body: string;
+    title: string;
+}
 
 @PaginatedCrudCollection({
     name: 'posts',
 })
 @Injectable()
-export class PostsState extends PaginatedCrudCollectionState<any, string> {
+export class PostsState extends PaginatedCrudCollectionState<Post, Post['id']> implements AfterSuccess<Post> {
+
+    afterSuccess(data: any | any[], operation: OperationContext): void | Observable<any> {
+    }
+
 }

--- a/apps/ng-integration/src/app/app.component.html
+++ b/apps/ng-integration/src/app/app.component.html
@@ -11,6 +11,11 @@
             </a>
         </div>
         <div class="px-3">
+            <a routerLink="/posts/await">
+                Await
+            </a>
+        </div>
+        <div class="px-3">
             <a routerLink="/posts/paginated">
                 Paginated
             </a>

--- a/apps/ng-integration/src/app/app.component.ts
+++ b/apps/ng-integration/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter, tap } from 'rxjs/operators';
 
 @Component({
     selector: 'app-root',
@@ -6,4 +8,12 @@ import { Component } from '@angular/core';
     styles: [],
 })
 export class AppComponent {
+
+    constructor(private router: Router) {
+        this.router.events.pipe(
+            filter(event => event instanceof NavigationEnd),
+            tap(event => console.log(event.constructor.name)),
+        ).subscribe();
+    }
+
 }

--- a/apps/ng-integration/src/app/posts/posts-routing.module.ts
+++ b/apps/ng-integration/src/app/posts/posts-routing.module.ts
@@ -31,6 +31,24 @@ const routes: Routes = [
         }],
     },
     {
+        path: 'await',
+        component: PostsIndexComponent,
+        data: instructions({
+            'entities': reset(),
+            'entities.posts': [
+                deactivate(),
+                getMany({ await: true }),
+            ],
+        }),
+        children: [{
+            path: ':id',
+            component: PostsShowComponent,
+            data: instructions({
+                'entities.posts': getActive({ await: true }),
+            }),
+        }],
+    },
+    {
         path: 'paginated',
         component: PostsIndexComponent,
         data: instructions({

--- a/libs/angular/src/crud-collection-state/after-success.interface.ts
+++ b/libs/angular/src/crud-collection-state/after-success.interface.ts
@@ -1,0 +1,12 @@
+import { OperationContext } from '@lyxs/angular/internal';
+import { Observable } from 'rxjs';
+
+export interface AfterSuccess<Entity = any> {
+
+    /**
+     * Will be run after every successful operation. A good use case for this is to render json-ld elements
+     * on the server platform for SEO purposes.
+     */
+    afterSuccess(data: Entity | Entity[], operation: OperationContext): void | Observable<any>;
+
+}

--- a/libs/angular/src/crud-collection-state/crud-collection.state.spec.ts
+++ b/libs/angular/src/crud-collection-state/crud-collection.state.spec.ts
@@ -50,7 +50,11 @@ const newPostData = {
     baseUrl: 'https://jsonplaceholder.typicode.com',
 })
 @Injectable()
-class PostsEntitiesState extends CrudCollectionState<Post, number> { }
+class PostsEntitiesState extends CrudCollectionState<Post, number> {
+
+    afterSuccess(data: Post | Post[]) { }
+
+}
 
 @CrudCollection<CrudCollectionReducer>({
     name: 'mongodbPosts',
@@ -368,6 +372,23 @@ describe('CrudCollectionState', () => {
         req.flush(postsData[0]);
         expect(postsState.snapshot.ids).toEqual([]);
         expect(postsState.snapshot.active.id).toEqual(1);
+    }));
+
+    it('should call afterSuccess', inject([
+        HttpTestingController,
+        PostsEntitiesState,
+    ], (
+        httpMock: HttpTestingController,
+        postsState: PostsEntitiesState,
+    ) => {
+        const spy = spyOn(postsState, 'afterSuccess');
+        postsState.getMany().toPromise();
+
+        const req = httpMock.expectOne(getCollectionUrl(postsState));
+        expect(req.request.method).toEqual('GET');
+        req.flush(postsData);
+
+        expect(spy).toHaveBeenCalled();
     }));
 
     afterEach(inject([HttpTestingController], (httpMock: HttpTestingController) => {

--- a/libs/angular/src/crud-collection-state/crud-collection.state.ts
+++ b/libs/angular/src/crud-collection-state/crud-collection.state.ts
@@ -414,7 +414,7 @@ export class CrudCollectionState<Entity = {}, IdType extends EntityIdType = stri
             options.success ? tap(result => options.success(result)) : tap(),
             mergeMap(result => {
                 if (typeof this['afterSuccess'] === 'function') {
-                    const source = this['afterSuccess']();
+                    const source = this['afterSuccess'](result, options.context);
                     if (source && isObservable(source)) {
                         return source.pipe(mapTo(result));
                     }

--- a/libs/angular/src/public_api.ts
+++ b/libs/angular/src/public_api.ts
@@ -1,3 +1,4 @@
+export { AfterSuccess } from './crud-collection-state/after-success.interface';
 export { CrudCollectionOptionsProvider, CRUD_COLLECTION_OPTIONS_TOKEN } from './crud-collection-state/constants';
 export { CrudCollection, CrudCollectionOptions } from './crud-collection-state/crud-collection.decorator';
 export { CrudCollectionReducer, CrudCollectionState } from './crud-collection-state/crud-collection.state';


### PR DESCRIPTION
feat: implement afterSuccess function
    
    if an afterSuccess function is defined on a CrudCollection, it will run
    every time a request was successful. you can even return an observable
    and the initial observable will wait for completion. this is handy for
    creating script-ld tags on ssr for example, so the request waits until
    this is done to resolve.

refactor: unify sequence of pipes via the requestPipe
    
    we ran a sequence of pipes for every request. for better structure,
    there is now a requestPipe unifying all of the pipes in one.